### PR TITLE
Add comment for BCM2708_PERI_BASE

### DIFF
--- a/configDS18B20.c
+++ b/configDS18B20.c
@@ -65,6 +65,8 @@
 // Access from ARM Running Linux
 
 //#define BCM2708_PERI_BASE        0x20000000
+// For RPi 1: 0x20000000
+// For RPi 2 or 3: 0x3F000000
 
 unsigned long BCM2708_PERI_BASE=0x20000000;
 


### PR DESCRIPTION
For the Raspberry Pi 1 use: 0x20000000
For the Raspberry Pi 2 or 3 use: 0x3F000000