### PR TITLE
Fix for a SEGFAULT during read

### DIFF
--- a/python/DS18B20.c
+++ b/python/DS18B20.c
@@ -1370,8 +1370,8 @@ static PyObject* MAX31850_readTemperature(PyObject* self, PyObject* args)
 #if PY_MAJOR_VERSION == 3
      PyObject * Idstr = PyUnicode_AsEncodedString(Pytemp, "utf-8","Error ~");
      char * p = PyBytes_AS_STRING(Idstr);
-     Py_XDECREF(Idstr);
      ID    = SensorIdToLLong(p);
+     Py_XDECREF(Idstr);
 #else
     ID     = SensorIdToLLong(PyString_AsString(Pytemp));
 #endif
@@ -1484,8 +1484,8 @@ static PyObject* DS18B20_readTemperature(PyObject* self, PyObject* args)
 #if PY_MAJOR_VERSION == 3
      PyObject * Idstr = PyUnicode_AsEncodedString(Pytemp, "utf-8","Error ~");
      char * p = PyBytes_AS_STRING(Idstr);
-     Py_XDECREF(Idstr);
      ID    = SensorIdToLLong(p);
+     Py_XDECREF(Idstr);
 #else
     ID     = SensorIdToLLong(PyString_AsString(Pytemp));
 #endif
@@ -1655,8 +1655,8 @@ static PyObject* DS18B20_readScratchPad(PyObject* self, PyObject* args)
 #if PY_MAJOR_VERSION == 3
      PyObject * Idstr = PyUnicode_AsEncodedString(Pytemp, "utf-8","Error ~");
      char * p = PyBytes_AS_STRING(Idstr);
-     Py_XDECREF(Idstr);
      ID    = SensorIdToLLong(p);
+     Py_XDECREF(Idstr);
 #else
     ID     = SensorIdToLLong(PyString_AsString(Pytemp));
 #endif
@@ -1745,8 +1745,8 @@ static PyObject* DS18B20_getResolution(PyObject* self, PyObject* args)
 #if PY_MAJOR_VERSION == 3
      PyObject * Idstr = PyUnicode_AsEncodedString(Pytemp, "utf-8","Error ~");
      char * p = PyBytes_AS_STRING(Idstr);
-     Py_XDECREF(Idstr);
      ID    = SensorIdToLLong(p);
+     Py_XDECREF(Idstr);
 #else
     ID     = SensorIdToLLong(PyString_AsString(Pytemp));
 #endif
@@ -1848,8 +1848,8 @@ static PyObject* DS18B20_setResolution(PyObject* self, PyObject* args)
 #if PY_MAJOR_VERSION == 3
      PyObject * Idstr = PyUnicode_AsEncodedString(Pytemp, "utf-8","Error ~");
      char * p = PyBytes_AS_STRING(Idstr);
-     Py_XDECREF(Idstr);
      ID    = SensorIdToLLong(p);
+     Py_XDECREF(Idstr);
 #else
     ID     = SensorIdToLLong(PyString_AsString(Pytemp));
 #endif


### PR DESCRIPTION
Bonjour,

Here's a fix for an intermittent SEGFAULT that occurs when reading temperature. The underlying byte pointer `Idstr`  is reclaimed (albeit intermittently) as `Py_XDECREF` is called before the contents of the converted string is used in `SensorIdToLong`, thus creating a SEGFAULT condition. This condition is prevalent when this library is used from a python threaded module.

The fix is quite simple and only requires moving the call to `Py_XDECREF` after `SensorIdToLong`.

Au plaisir.
Will.

 